### PR TITLE
Render diagrams only when they're on the current slide

### DIFF
--- a/sequence-diagrams-plugin.js
+++ b/sequence-diagrams-plugin.js
@@ -4,8 +4,8 @@ var RevealSequenceDiagram = window.RevealSequenceDiagram || (function(){
 	var classNameBuilt = "sequence-diagram-built";
 	var config = Reveal.getConfig().sequencediagrams;
 
-	function onRevealJsReady(event){
-		var elements = document.getElementsByClassName(className);
+	function onRevealJsSlideChanged(event){
+		var elements = event.currentSlide.getElementsByClassName(className);
 		for (var i = 0; i < elements.length; i++ ){
 			var diagramBlueprintElement = elements[i];
 
@@ -88,7 +88,7 @@ var RevealSequenceDiagram = window.RevealSequenceDiagram || (function(){
 		return defaultOption;
 	}
 
-	Reveal.addEventListener('ready',onRevealJsReady);
+	Reveal.addEventListener('slidechanged',onRevealJsSlideChanged);
 
 })();
 


### PR DESCRIPTION
Otherwise, they're rendered on reveal.js's load,
and if the slides with diagrams are not nearby,
they'll have a fake size (probably 0 by 0) for rendering into,
resulting in a needlessly compressed diagram.